### PR TITLE
Remove update check

### DIFF
--- a/xnbcli.js
+++ b/xnbcli.js
@@ -17,8 +17,8 @@ let fail = 0;
 // define the version number
 const VERSION = '1.0.7';
 
-// async wrapper for function
-(async () => {
+// check for updates
+async function checkUpdate() {
 
     try {
         // fetch the package.json to see if there's a new version available
@@ -36,7 +36,9 @@ const VERSION = '1.0.7';
         Log.error('Failed to search for a new update. Application should still function normally.');
         Log.error(error);
     }
-    
+}
+
+(() => {
     // call the init function to get the party started
     init();
 


### PR DESCRIPTION
Temporarily removing the update check.

Some regions have issues connecting to GitHub (without a system-wide proxy), so it's very frustrating when the program doesn't respond and the check can't be bypassed.