### PR TITLE
Fix buffer concat Uint8Array error

### DIFF
--- a/app/BufferWriter.js
+++ b/app/BufferWriter.js
@@ -39,16 +39,16 @@ class BufferWriter {
 
     concat(buffer) {
         this.alloc(buffer.length);
-        buffer.copy(this._buffer, this.bytePosition);
+        this._buffer.set(buffer, this.bytePosition);
         this.bytePosition += buffer.length;
     }
 
     /**
      * Writes bytes to the buffer
-     * @param {Mixed} bytes 
+     * @param {Mixed} string 
      */
-    write(bytes, length = Buffer.byteLength(bytes)) {
-        this.alloc(length).buffer.write(bytes, this.bytePosition);
+    write(string, length = Buffer.byteLength(string)) {
+        this.alloc(length).buffer.write(string, this.bytePosition);
         this.bytePosition += length;
     }
 


### PR DESCRIPTION
Follow up of #50. Texture2D writer may concat `Uint8Array` to the buffer, so we should use the common [`TypedArray.prototype.set()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/set) method.